### PR TITLE
Remove noncompliant characters from identifiers, and other fixes

### DIFF
--- a/batch.js
+++ b/batch.js
@@ -9,7 +9,7 @@ if (!fs.existsSync(dir)){
 
 var base = new Airtable({apiKey: process.env.APIKEY}).base(process.env.BASE);
 
-base('🍩 Oral Histories').select({
+base('Oral Histories').select({
     // Selecting the first 3 records in Worksheet:
     // maxRecords: 3,
     view: ".LOCMetadataView",

--- a/mkvid.sh
+++ b/mkvid.sh
@@ -14,6 +14,7 @@ flagger () {
   open=false
   dev=false
   videos=()
+  identifiers=()
   for arg in "$@"; do
     if [[ $arg == "-d" || $arg == "--dev" ]]; then
       dev=true
@@ -33,9 +34,10 @@ video () {
   else
     for arg in ${videos[*]}; do
       directorator "$arg"
+      renamer "$arg"
     done
     if [[ $open == true ]]; then
-      for arg in ${videos[*]}; do
+      for arg in ${identifiers[*]}; do
         open "$destination"/"$arg"
       done
     fi
@@ -60,6 +62,24 @@ directorator () {
       echo "\e[31mSomething went wrong\e[0m"
     fi
   fi
+}
+
+# Rename directory to S3-compliant identifier
+renamer () {
+  # Convert to ascii characters
+  identifier=$(echo $1 | iconv -f UTF-8 -t ascii//TRANSLIT//ignore)
+
+  # Remove characters left by Mac iconv implementation
+  identifier=${identifier//[\'\^\~\"]/''}
+
+  # Change + to -
+  identifier=${identifier//\+/'-'}
+
+  if [ $identifier != $1 ]; then
+    mv "$destination"/"$1" "$destination"/"$identifier"
+  fi
+
+  identifiers+=("$identifier")
 }
 
 # Runner

--- a/mkvid.sh
+++ b/mkvid.sh
@@ -70,7 +70,7 @@ renamer () {
   identifier=$(echo $1 | iconv -f UTF-8 -t ascii//TRANSLIT//ignore)
 
   # Remove characters left by Mac iconv implementation
-  identifier=${identifier//[\'\^\~\"]/''}
+  identifier=${identifier//[\'\^\~\"\`]/''}
 
   # Change + to -
   identifier=${identifier//\+/'-'}

--- a/single.js
+++ b/single.js
@@ -8,7 +8,7 @@ require('dotenv').config({ path: local+"/.env" });
 var single = process.argv[2];
 var base = new Airtable({apiKey: process.env.APIKEY}).base(process.env.BASE);
 
-base('🍩 Oral Histories').select({
+base('Oral Histories').select({
     view: ".LOCMetadataView",
     cellFormat: "string",
     timeZone: "America/New_York",
@@ -33,7 +33,7 @@ base('🍩 Oral Histories').select({
 }).eachPage(function page(records, fetchNextPage) {
   if (!Array.isArray(records) || !!records.length) {
     records.forEach(function(record) {
-        const content = [`Metadata for ${record.get('Identifier')}
+        const content = `Metadata for ${record.get('Identifier')}
 
 Oral History ID:  ${record.get('Identifier')}
 Languages by ISO 639-3 Code: ${record.get('Languages: ISO Code (639-3)')}
@@ -50,7 +50,7 @@ Video Territory: ${record.get('Coverage: Video Territory')}
 
 Published to Youtube on: ${record.get('Youtube Publish Date')}
 Wikimedia Status: ${record.get('Wikimedia Eligibility')}
-Wiki Commons URL: ${record.get('Wiki Commons URL')}`]
+Wiki Commons URL: ${record.get('Wiki Commons URL')}`;
 
         fs.writeFileSync(`${destination}/${single}/${record.get('Identifier')}__metadata.txt`, content);
     });


### PR DESCRIPTION
- Replace S3-noncompliant characters in directory name
  - Replace + with -
  - Remove diacritics
- Corrected oral histories table name
- Fixed an error with the `writeFileSync` call I was getting with node v15.0.1