### PR TITLE
Add lexicon template script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wikitongues
 # Oral History Template Instantiator
 
-This tool sets up the folder structure for a new Wikitongues oral history.
+This tool sets up the folder structure for new Wikitongues Oral Histories and Lexicons.
 
 ## Prerequisites
 
@@ -91,12 +91,11 @@ The most important commands to know are:
 Now you are ready to run the Oral History Template Instantiator.
 
 ## Usage
-
+### Oral History Template
 Run this command, replacing Identifier with an actual oral history identifier from Airtable.
 ```
-./mkvid.sh "Identifier"
+mkvid "Identifier"
 ```
-
 It will create a folder with this structure in the destination directory that you specified when running the setup script.
 ```
 Identifier/
@@ -108,6 +107,17 @@ Identifier/
 │   │   └── converted/
 │   ├── Premier Project/
 │   └── thumbnail/
+└── Identifier__metadata.txt    Metadata retrieved from Airtable
+```
+
+### Lexicon Template
+Run this command, replacing Identifier with an actual lexicon identifier from Airtable.
+```
+mklex "Identifier"
+```
+It will create a folder with this structure in the destination directory that you specified when running the setup script.
+```
+Identifier/
 └── Identifier__metadata.txt    Metadata retrieved from Airtable
 ```
 

--- a/getLexiconMetadata.js
+++ b/getLexiconMetadata.js
@@ -1,0 +1,77 @@
+const Airtable = require('airtable');
+const fs = require('fs');
+const path = require('path');
+
+const identifier = process.argv[2];
+const repo = process.argv[3];
+const destination = process.argv[4];
+const fileIdentifier = process.argv[5];
+
+require('dotenv').config({ path: repo + '/.env' });
+
+const base = new Airtable({apiKey: process.env.APIKEY}).base(process.env.BASE);
+
+const TABLE = 'Lexicons';
+const VIEW = 'Public Archival View';
+const CELL_FORMAT = 'string';
+const TIME_ZONE = 'America/New_York';
+const USER_LOCALE = 'en-ca';
+const ID_FIELD = 'Identifier';
+
+const FIELDS = [
+  'Identifier',
+  'Title',
+  'Subject [Languages]',
+  'Creator',
+  'Description',
+  'Date [Created]',
+  'Subject [Source Language: Genealogy]',
+  'Subject [Source Language: Continent]',
+  'Subject [Source Language: Nation]',
+  'Language [Source]',
+  'Language [Source: ISO 639-3]',
+  'Language [Source: Glottocode]',
+  'Language [Source Dialect: Glottocode]',
+  'Language [Source Macrolanguage: ISO 639-3]',
+  'Language [Target]',
+  'Language [Target: ISO 639-3]',
+  'Language [Target: Glottocode]',
+  'Language [Target Dialect: Glottocode]',
+  'Language [Target Macrolanguage: ISO 639-3]',
+  'Publisher',
+  'Format [Medium]',
+  'Format [Extent]',
+  'Relation [Requires]',
+  'Type',
+  'Type [Document: LOC]',
+  'Type [Document Category: LOC]',
+  'Coverage [Nation]',
+  'Coverage [Territory]',
+  'Coverage [Dropbox]',
+  'Coverage [Web]',
+  'Relation [Is Version Of]',
+  'Relation [Is Part Of]',
+  'Rights'
+];
+
+base(TABLE).select({
+  view: VIEW,
+  cellFormat: CELL_FORMAT,
+  timeZone: TIME_ZONE,
+  userLocale: USER_LOCALE,
+  filterByFormula: `${ID_FIELD}='${identifier}'`,
+  fields: FIELDS
+}).firstPage((err, records) => {
+  if (err) {
+    console.error(err);
+    return process.exit(1);
+  }
+  if (records.length !== 1) {
+    console.error(`${records.length} records found for identifier ${identifier}`);
+    return process.exit(1);
+  }
+  const record = records[0];
+  const content = FIELDS.map(field => `${field}: ${record.get(field)}`).join('\n');
+
+  fs.writeFileSync(`${path.resolve(destination)}/${fileIdentifier}/${fileIdentifier}__metadata.txt`, content);
+});

--- a/mklex.sh
+++ b/mklex.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+error () {
+  printf "\e[31m$1\e[0m\n" "${@:2}"
+}
+
+success () {
+  printf "\e[32m$1\e[0m\n" "${@:2}"
+}
+
+warning () {
+  printf "\e[33m$1\e[0m\n" "${@:2}"
+}
+
+println () {
+  printf "$1\n" "${@:2}"
+}
+
+# ~/wikitongues-config is where the necessary locations for this operation get stored.
+# The file is created by the setup.sh script.
+if [[ ! -f ~/wikitongues-config ]]; then
+  error "Settings not configured."
+  println "From within the Oral-History-Template-Instantiator directory, please run the setup script: "
+  println "> ./setup.sh"
+  exit 1
+fi
+
+source ~/wikitongues-config
+
+# The metadata address is the absolute path to where the airtable API script live
+metadataPath=$metadata
+# The destination address is the absolute path to where you want the lexicon templates to be created.
+destination=$lexiconDestination
+
+if [[ -z $destination ]]; then
+  error "Settings not configured for mklex."
+  println "From within the Oral-History-Template-Instantiator directory, please run the setup script: "
+  println "> ./setup.sh"
+  exit 1
+fi
+
+# Reads flags
+flagger () {
+  open=false
+  dev=false
+  makeMetadataFile=true
+  lexicons=()
+  identifiers=()
+  for arg in "$@"; do
+    if [[ $arg == '-d' || $arg == '--dev' ]]; then
+      dev=true
+    elif [[ $arg == '-o' || $arg == '--open' ]]; then
+      open=true
+    else
+      lexicons+=("$arg")
+    fi
+  done
+  if [[ ! $airtableConfig || $airtableConfig == false ]]; then
+    makeMetadataFile=false
+    warning "Airtable API not configured. No metadata file will be automatically produced."
+  fi
+}
+
+runner () {
+  destination="$1"
+
+  if [ -z "${lexicons[*]}" ]; then
+    warning "Please specify at least one lexicon ID"
+    exit 1
+  fi
+
+  for lexiconId in ${lexicons[*]}; do
+    directorator "$destination" "$lexiconId"
+  done
+  if [[ $open == true ]]; then
+    for id in ${identifiers[*]}; do
+      open "$destination"/"$id"
+    done
+  fi
+}
+
+directorator () {
+  destination="$1"
+  lexiconId="$2"
+
+  identifier=$(renamer "$destination" "$lexiconId")
+  identifiers+=("$identifier")
+
+  if [ "$identifier" != "$lexiconId" ]; then
+    warning "Directory for %s is named %s for archival compatibility." "$lexiconId" "$identifier"
+  fi
+
+  if [ -d "$destination"/"$identifier" ]; then
+    println "A directory named %s already exists in this location. Skipping." "$identifier"
+    return
+  fi
+
+  mkdir "$destination"/"$identifier"
+
+  if [[ $makeMetadataFile == true ]]; then
+    node "$metadataPath"/getLexiconMetadata.js "$lexiconId" "$metadata" "$destination" "$identifier"
+    if [ $? != 0 ]; then
+      rm -r "$destination"/"$identifier"
+      exit 1
+    fi
+  fi
+
+  if [ -d "$destination"/"$identifier" ]; then
+    success "Lexicon directory successfully created for %s." "$lexiconId"
+  else
+    error "Something went wrong."
+    exit 1
+  fi
+}
+
+# Rename directory to S3-compliant identifier for LOC archival
+renamer () {
+  destination="$1"
+  lexiconId="$2"
+
+  # Convert to ascii characters
+  identifier=$(echo "$lexiconId" | iconv -f UTF-8 -t ascii//TRANSLIT//ignore)
+
+  # Remove characters left by Mac iconv implementation
+  identifier=${identifier//[\'\^\~\"\`]/''}
+
+  # Change + to -
+  identifier=${identifier//\+/'-'}
+
+  echo "$identifier"
+}
+
+flagger "$@"
+
+if [[ $dev == true ]]; then
+  runner "."
+else
+  runner "$destination"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,24 +1,45 @@
 #!/bin/bash
 
 preview () {
-	sed 1d ~/wikitongues-config ;
+  sed 1d ~/wikitongues-config ;
 }
 
 abort () {
-	echo "Exiting without changes. "
+  echo "Exiting without changes to configuration. "
 }
+
 writeDestination () {
-	sed -i '' '/^d/d'  ~/wikitongues-config
-	read -r -p "Please enter the absolute path to where you want the Oral History directories to be created: $(printf '\n ')Example: /Users/$USER/desktop/Wikitongues $(printf '\n> ') " destination
-	printf 'destination="%s"\n' "$destination" >> ~/wikitongues-config ;
+  deleteVar='/^destination/d'
+  sed -i '' $deleteVar ~/wikitongues-config
+  read -r -p "Please enter the absolute path to where you want the Oral History directories to be created: $(printf '\n ')Example: /Users/$USER/Desktop/Wikitongues $(printf '\n> ') " destination
+  printf 'destination="%s"\n' "$destination" >> ~/wikitongues-config ;
 }
 
 updateDestination () {
-	read -r -p "Would you like to change your destination folder? [y/N] " response
+  read -r -p "Would you like to set your destination folder for Oral Histories? [y/N] " response
   case "$response" in
     [yY][eE][sS]|[yY])
       echo ""
       writeDestination
+      ;;
+    *)
+      ;;
+  esac
+}
+
+writeDestinationForLexicons () {
+  deleteVar='/^lexiconDestination/d'
+  sed -i '' $deleteVar ~/wikitongues-config
+  read -r -p "Please enter the absolute path to where you want the Lexicon directories to be created: $(printf '\n ')Example: /Users/$USER/Desktop/Wikitongues $(printf '\n> ') " destination
+  printf 'lexiconDestination="%s"\n' "$destination" >> ~/wikitongues-config ;
+}
+
+updateDestinationForLexicons () {
+  read -r -p "Would you like to set your destination folder for Lexicons? [y/N] " response
+  case "$response" in
+    [yY][eE][sS]|[yY])
+      echo ""
+      writeDestinationForLexicons
       ;;
     *)
       abort ;
@@ -28,56 +49,48 @@ updateDestination () {
 
 echo "Welcome to the Wikitongues Oral History Maker setup script."
 
-
-
 if [[ -f ~/wikitongues-config ]]; then
+  # Update scripts and optionally prompt to update destination settings
   printf "A configuration file already exists. \n\n––––––––––––––––––––––––––––\n$(date)\n\nCurrent settings:\n" 
   preview
   echo ""
-  if [[ -f /usr/local/bin/mkvid ]]; then
-  	echo ""
-  	updateDestination
-  else
-  	read -r -p "Script not installed - install now? [y/N] " response
-	  case "$response" in
-      [yY][eE][sS]|[yY])
-        echo ""
-        cp mkvid.sh /usr/local/bin/mkvid
-        chmod +x /usr/local/bin/mkvid
-        echo "Script successfully installed."
-        updateDestination
-        ;;
-      *)
-        abort ;
-        ;;
-    esac
-  fi
-else
-	# Fresh install
   echo "Installing script..."
   sleep .8 
   cp mkvid.sh /usr/local/bin/mkvid
   chmod +x /usr/local/bin/mkvid
+  cp mklex.sh /usr/local/bin/mklex
+  chmod +x /usr/local/bin/mklex
+  updateDestination
+  updateDestinationForLexicons
+else
+  # Fresh install
+  echo "Installing script..."
+  sleep .8 
+  cp mkvid.sh /usr/local/bin/mkvid
+  chmod +x /usr/local/bin/mkvid
+  cp mklex.sh /usr/local/bin/mklex
+  chmod +x /usr/local/bin/mklex
   echo "Configuring script. Creating a wikitongues-config file..."
   sleep 1 ;
   printf "# This wikitongues-config file is necessary for Wikitongues utilities like making oral history directories and working on the archives.\n" > ~/wikitongues-config
-	echo 'method="/usr/local/bin/mkvid"' >> ~/wikitongues-config ;
-	writeDestination
-	
-	printf 'metadata="'"$(pwd)"'"\n' >> ~/wikitongues-config ;
-	printf "\nSetup complete.\nSettings file can be located at ~/wikitongues-config\n\nPreview below:\n" ;
+  echo 'method="/usr/local/bin/mkvid"' >> ~/wikitongues-config ;
+  writeDestination
+  writeDestinationForLexicons
+  
+  printf 'metadata="'"$(pwd)"'"\n' >> ~/wikitongues-config ;
+  printf "\nSetup complete.\nSettings file can be located at ~/wikitongues-config\n\nPreview below:\n" ;
 
-	if [[ ! -f ./.env ]]; then
-		printf "\nAccess to the Airtable database is necessary for the automatic creation of metadata files.\n"
-		
-		read -r -p "Would you like to configure your Airtable access now? [y/N] " response
-	  case "$response" in
+  if [[ ! -f ./.env ]]; then
+    printf "\nAccess to the Airtable database is necessary for the automatic creation of metadata files.\n"
+    
+    read -r -p "Would you like to configure your Airtable access now? [y/N] " response
+    case "$response" in
       [yY][eE][sS]|[yY])
-				touch .env
+        touch .env
         read -r -p "Please enter your Airtable API key: (Please reach out to your supervisor if you need help)$(printf '\n ')" key
-				printf 'APIKEY=%s\n' "$key" >> .env ;
-				read -r -p "Please enter the Wikitongues Base ID: $(printf '\n ')" base
-				printf 'BASE=%s\n' "$base" >> .env ;
+        printf 'APIKEY=%s\n' "$key" >> .env ;
+        read -r -p "Please enter the Wikitongues Base ID: $(printf '\n ')" base
+        printf 'BASE=%s\n' "$base" >> .env ;
         echo "airtableConfig=true" >> ~/wikitongues-config ;
         sleep .7
         echo "Airtable API access successfully configured!"
@@ -87,7 +100,7 @@ else
         ;;
     esac
   else
-  	echo "airtableConfig=true" >> ~/wikitongues-config ;
-	fi
-	preview	;
+    echo "airtableConfig=true" >> ~/wikitongues-config ;
+  fi
+  preview	;
 fi

--- a/single.js
+++ b/single.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var single = process.argv[2];
 var local = process.argv[3]
 var destination = process.argv[4]
+var fileIdentifier = process.argv[5]
 require('dotenv').config({ path: local+"/.env" });
 
 
@@ -56,7 +57,7 @@ Published to Youtube on: ${record.get(fieldNames.YOUTUBE_PUBLISH_DATE)}
 Wikimedia Status: ${record.get(fieldNames.WIKIMEDIA_ELIGIBILITY)}
 Wiki Commons URL: ${record.get(fieldNames.COVERAGE_WIKIMEDIA_COMMONS)}`;
 
-        fs.writeFileSync(`${destination}/${single}/${record.get(fieldNames.ID)}__metadata.txt`, content);
+        fs.writeFileSync(`${destination}/${fileIdentifier}/${record.get(fieldNames.ID)}__metadata.txt`, content);
     });
     fetchNextPage();
   } else {


### PR DESCRIPTION
* Add a lexicon template script as a companion to the oral history script.
* Update the setup script to install the lexicon script, and update both scripts when it is run.
* Fix bugs found in `mkvid`

The command to create a lexicon template is `mklex`. Its usage is just like `mkvid`, and it creates the following template for lexicons:
```
Identifier/
└── Identifier__metadata.txt    Metadata retrieved from Airtable
```
To install, just run the setup script. It will install the `mklex` command and prompt you to set the destination path for lexicons.
```
(base) scottrohrer@Scotts-Air-2 Oral-History-Template-Instantiator % ./setup.sh 
Welcome to the Wikitongues Oral History Maker setup script.
A configuration file already exists. 

––––––––––––––––––––––––––––
Sun Apr 17 14:06:31 EDT 2022

Current settings:
method="/usr/local/bin/mkvid"
metadata="/Users/scottrohrer/Documents/wikitongues/Oral-History-Template-Instantiator"
airtableConfig=true
destination="$HOME/Desktop"

Installing script...
Would you like to set your destination folder for Oral Histories? [y/N] N
Would you like to set your destination folder for Lexicons? [y/N] y

Please enter the absolute path to where you want the Lexicon directories to be created: 
 Example: /Users/scottrohrer/Desktop/Wikitongues 
>  $HOME/Desktop
(base) scottrohrer@Scotts-Air-2 Oral-History-Template-Instantiator % 
```
To run:
```
mklex identifier_1 identifier_2
```
To open the new lexicon folders in Finder:
```
mklex identifier_1 identifier_2 -o
```
